### PR TITLE
Fix configuration properties not showing in SonarQube Administration UI.

### DIFF
--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforcePlugin.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforcePlugin.java
@@ -22,16 +22,20 @@ package org.sonar.plugins.scm.perforce;
 import com.google.common.collect.ImmutableList;
 import org.sonar.api.SonarPlugin;
 
+import java.util.ArrayList;
 import java.util.List;
 
 public final class PerforcePlugin extends SonarPlugin {
 
   @Override
   public List getExtensions() {
-    return ImmutableList.of(
+    List result = new ArrayList();
+    result.addAll(ImmutableList.of(
       PerforceScmProvider.class,
       PerforceBlameCommand.class,
-      PerforceConfiguration.class);
+      PerforceConfiguration.class));
+    result.addAll(PerforceConfiguration.getProperties());
+    return result;
   }
 
 }

--- a/src/test/java/org/sonar/plugins/scm/perforce/PerforcePluginTest.java
+++ b/src/test/java/org/sonar/plugins/scm/perforce/PerforcePluginTest.java
@@ -27,6 +27,6 @@ public class PerforcePluginTest {
 
   @Test
   public void getExtensions() {
-    assertThat(new PerforcePlugin().getExtensions()).hasSize(3);
+    assertThat(new PerforcePlugin().getExtensions()).hasSize(10);
   }
 }


### PR DESCRIPTION
In newer versions of SonarQube, properties must be added to the Plugin's
extension list, specified by getExtensions().

Working example:
https://github.com/SonarSource/sonar-scm-svn/blob/1.2/src/main/java/org/sonar/plugins/scm/svn/SvnPlugin.java#L37