### PR TITLE
Retrieve date and username per changelist number.

### DIFF
--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforceBlameCommand.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforceBlameCommand.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nonnull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.sonar.api.batch.fs.FileSystem;
@@ -110,6 +111,7 @@ public class PerforceBlameCommand extends BlameCommand {
    * Creating options for file annotation command.
    * @return options for requests.
    */
+  @Nonnull
   private static GetFileAnnotationsOptions getFileAnnotationOptions() {
     GetFileAnnotationsOptions options = new GetFileAnnotationsOptions();
     options.setUseChangeNumbers(true);
@@ -123,7 +125,8 @@ public class PerforceBlameCommand extends BlameCommand {
    * in the current client workspace.
    * @param inputFile file to create file spec for
    */
-  private static IFileSpec createFileSpec(InputFile inputFile) {
+  @Nonnull
+  private static IFileSpec createFileSpec(@Nonnull InputFile inputFile) {
     IFileSpec fileSpec = new FileSpec(PerforceExecutor.encodeWildcards(inputFile.absolutePath()));
     fileSpec.setEndRevision(IFileSpec.HAVE_REVISION);
     return fileSpec;

--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforceExecutor.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforceExecutor.java
@@ -37,6 +37,7 @@ import java.io.File;
 import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Properties;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
@@ -58,14 +59,10 @@ public class PerforceExecutor {
   /**
    * Instantiates a new p4 command helper.
    *
-   * @param repository
-   *            the repository
-   * @param fileSet
-   *            the file set
-   * @param logger
-   *            the logger
-   * @throws ScmException
-   *             the scm exception
+   * @param config
+   *            the plugin configuration
+   * @param workDir
+   *            the working directory
    */
   public PerforceExecutor(PerforceConfiguration config, File workDir) {
     this.config = config;
@@ -79,25 +76,6 @@ public class PerforceExecutor {
    */
   public IOptionsServer getServer() {
     return server;
-  }
-
-  /**
-   * Gets the client.
-   *
-   * @return the client
-   */
-  public IClient getClient() {
-    return client;
-  }
-
-  /**
-   * Sets the client.
-   *
-   * @param client
-   *            the new client
-   */
-  public void setClient(IClient client) {
-    this.client = client;
   }
 
   /**
@@ -167,11 +145,7 @@ public class PerforceExecutor {
       return true;
     }
     // If there is a broker or something else that swallows the message
-    if (status.isEmpty()) {
-      return true;
-    }
-
-    return false;
+    return status.isEmpty();
   }
 
   private void createServer() throws URISyntaxException, P4JavaException {
@@ -295,10 +269,10 @@ public class PerforceExecutor {
   /**
    * Creates the client view mapping.
    *
-   * @param repo
-   *            the repo
    * @param basedir
    *            the basedir
+   * @param p4ClientName
+   *            the Perforce client name
    * @return the client view mapping
    */
   private ClientViewMapping createClientViewMapping(File basedir, String p4ClientName) {
@@ -315,7 +289,8 @@ public class PerforceExecutor {
    *            the path
    * @return the repo location
    */
-  private String getRepoLocation(String path) {
+  @Nullable
+  private String getRepoLocation(@Nonnull String path) {
     String location = null;
     if (StringUtils.isNotBlank(path) && client != null) {
       try {
@@ -340,7 +315,8 @@ public class PerforceExecutor {
    *            the repo path
    * @return the canonical repo path
    */
-  private static String getCanonicalRepoPath(String repoPath) {
+  @Nullable
+  private static String getCanonicalRepoPath(@Nullable String repoPath) {
     if (repoPath == null) {
       return null;
     }
@@ -359,6 +335,7 @@ public class PerforceExecutor {
    * @param filePath the file path
    * @return the string
    */
+  @Nonnull
   static String encodeWildcards(@Nullable String filePath) {
     if (filePath != null) {
       return filePath.replaceAll("%", "%25").replaceAll("\\*", "%2A").replaceAll("#", "%23").replaceAll("@", "%40");

--- a/src/test/java/org/sonar/plugins/scm/perforce/PerforceBlameCommandTest.java
+++ b/src/test/java/org/sonar/plugins/scm/perforce/PerforceBlameCommandTest.java
@@ -19,18 +19,12 @@
  */
 package org.sonar.plugins.scm.perforce;
 
-import com.perforce.p4java.core.file.FileSpecOpStatus;
+import com.perforce.p4java.core.IChangelist;
 import com.perforce.p4java.core.file.IFileAnnotation;
-import com.perforce.p4java.core.file.IFileRevisionData;
-import com.perforce.p4java.core.file.IFileSpec;
 import com.perforce.p4java.option.server.GetFileAnnotationsOptions;
-import com.perforce.p4java.option.server.GetRevisionHistoryOptions;
 import com.perforce.p4java.server.IOptionsServer;
-import java.util.Arrays;
+import java.util.Collections;
 import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.junit.Test;
 import org.sonar.api.batch.fs.InputFile;
 import org.sonar.api.batch.scm.BlameCommand.BlameOutput;
@@ -54,7 +48,7 @@ public class PerforceBlameCommandTest {
     IFileAnnotation annotation = mock(IFileAnnotation.class);
     when(annotation.getDepotPath()).thenReturn(null);
 
-    when(server.getFileAnnotations(anyList(), any(GetFileAnnotationsOptions.class))).thenReturn(Arrays.asList(annotation));
+    when(server.getFileAnnotations(anyList(), any(GetFileAnnotationsOptions.class))).thenReturn(Collections.singletonList(annotation));
 
     command.blame(mock(InputFile.class), server, blameOutput);
 
@@ -71,24 +65,18 @@ public class PerforceBlameCommandTest {
     when(annotation.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(annotation.getLower()).thenReturn(3);
 
-    when(server.getFileAnnotations(anyList(), any(GetFileAnnotationsOptions.class))).thenReturn(Arrays.asList(annotation));
+    when(server.getFileAnnotations(anyList(), any(GetFileAnnotationsOptions.class))).thenReturn(Collections.singletonList(annotation));
 
-    Map<IFileSpec, List<IFileRevisionData>> result = new HashMap<>();
-    IFileSpec fileSpecResult = mock(IFileSpec.class);
-    when(fileSpecResult.getOpStatus()).thenReturn(FileSpecOpStatus.VALID);
-    IFileRevisionData revision3 = mock(IFileRevisionData.class);
-    when(revision3.getChangelistId()).thenReturn(3);
+    IChangelist changelist = mock(IChangelist.class);
     Date date = new Date();
-    when(revision3.getDate()).thenReturn(date);
-    when(revision3.getUserName()).thenReturn("jhenry");
-    result.put(fileSpecResult, Arrays.asList(revision3));
-
-    when(server.getRevisionHistory(anyList(), any(GetRevisionHistoryOptions.class))).thenReturn(result);
+    when(changelist.getDate()).thenReturn(date);
+    when(changelist.getUsername()).thenReturn("jhenry");
+    when(server.getChangelist(3)).thenReturn(changelist);
 
     InputFile inputFile = mock(InputFile.class);
     command.blame(inputFile, server, blameOutput);
 
-    verify(blameOutput).blameResult(inputFile, Arrays.asList(new BlameLine().revision("3").date(date).author("jhenry")));
+    verify(blameOutput).blameResult(inputFile, Collections.singletonList(new BlameLine().revision("3").date(date).author("jhenry")));
   }
 
 }

--- a/src/test/java/org/sonar/plugins/scm/perforce/PerforceBlameCommandTest.java
+++ b/src/test/java/org/sonar/plugins/scm/perforce/PerforceBlameCommandTest.java
@@ -23,6 +23,8 @@ import com.perforce.p4java.core.IChangelist;
 import com.perforce.p4java.core.file.IFileAnnotation;
 import com.perforce.p4java.option.server.GetFileAnnotationsOptions;
 import com.perforce.p4java.server.IOptionsServer;
+
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Date;
 import org.junit.Test;
@@ -33,6 +35,7 @@ import org.sonar.api.batch.scm.BlameLine;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyList;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
@@ -65,7 +68,7 @@ public class PerforceBlameCommandTest {
     when(annotation.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(annotation.getLower()).thenReturn(3);
 
-    when(server.getFileAnnotations(anyList(), any(GetFileAnnotationsOptions.class))).thenReturn(Collections.singletonList(annotation));
+    when(server.getFileAnnotations(anyList(), any(GetFileAnnotationsOptions.class))).thenReturn(Arrays.asList(annotation, annotation));
 
     IChangelist changelist = mock(IChangelist.class);
     Date date = new Date();
@@ -76,7 +79,35 @@ public class PerforceBlameCommandTest {
     InputFile inputFile = mock(InputFile.class);
     command.blame(inputFile, server, blameOutput);
 
-    verify(blameOutput).blameResult(inputFile, Collections.singletonList(new BlameLine().revision("3").date(date).author("jhenry")));
+    BlameLine line = new BlameLine().revision("3").date(date).author("jhenry");
+    verify(blameOutput).blameResult(inputFile, Arrays.asList(line, line));
+    verify(server, times(1)).getChangelist(3);
+  }
+
+  @Test
+  public void testBlameSubmittedFileLastEmptyLine() throws Exception {
+    BlameOutput blameOutput = mock(BlameOutput.class);
+    IOptionsServer server = mock(IOptionsServer.class);
+    PerforceBlameCommand command = new PerforceBlameCommand(mock(PerforceConfiguration.class));
+
+    IFileAnnotation annotation = mock(IFileAnnotation.class);
+    when(annotation.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
+    when(annotation.getLower()).thenReturn(3);
+
+    when(server.getFileAnnotations(anyList(), any(GetFileAnnotationsOptions.class))).thenReturn(Collections.singletonList(annotation));
+
+    IChangelist changelist = mock(IChangelist.class);
+    Date date = new Date();
+    when(changelist.getDate()).thenReturn(date);
+    when(changelist.getUsername()).thenReturn("jhenry");
+    when(server.getChangelist(3)).thenReturn(changelist);
+
+    InputFile inputFile = mock(InputFile.class);
+    when(inputFile.lines()).thenReturn(2);
+    command.blame(inputFile, server, blameOutput);
+
+    BlameLine line = new BlameLine().revision("3").date(date).author("jhenry");
+    verify(blameOutput).blameResult(inputFile, Arrays.asList(line, line));
   }
 
 }


### PR DESCRIPTION
See https://github.com/SonarSource/sonar-scm-perforce/pull/7

Turns out ```p4 filelog``` is garbage, so instead iterate each CL from the ```p4 annotate``` result and use ```p4 change -o```.  Results from ```p4 change -o``` are stored in a map for retrieval on later lines.  The map defined as a field for the instance in order to speed up analysis on subsequent files in case a CL spanned multiple files.

In order to get ```p4 filelog -i``` to list all possible changelists, it has to be run twice, once with ```-h``` and once without.  Analysis for 300 files took ~7min using that method, vs ~3.5min when using ```p4 change -o``` for each CL.  For 600 files, ~15.5min vs ~7.5min.  I haven't done any other performance comparisons.