### PR TITLE
Make hostname configurable via sonar.perforce.clientImpersonatedHostname

### DIFF
--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforceConfiguration.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforceConfiguration.java
@@ -43,6 +43,7 @@ public class PerforceConfiguration implements BatchComponent {
   private static final String USER_PROP_KEY = "sonar.perforce.username";
   private static final String PASSWORD_PROP_KEY = "sonar.perforce.password.secured";
   static final String CLIENT_PROP_KEY = "sonar.perforce.clientName";
+  private static final String CLIENT_IMPERSONATED_HOST_PROP_KEY = "sonar.perforce.clientImpersonatedHostname";
   private static final String CHARSET_PROP_KEY = "sonar.perforce.charset";
   private static final String SOCKSOTIMEOUT_PROP_KEY = "sonar.perforce.sockSoTimeout";
 
@@ -90,6 +91,15 @@ public class PerforceConfiguration implements BatchComponent {
         .subCategory(CATEGORY_PERFORCE)
         .index(3)
         .build(),
+      PropertyDefinition.builder(CLIENT_IMPERSONATED_HOST_PROP_KEY)
+        .name("Client impersonated hostname")
+        .description("Name of the host computer to impersonate, per the <a href=\"https://www.perforce.com/perforce/r15.1/manuals/cmdref/P4HOST.html\">Perforce documentation</a>")
+        .type(PropertyType.STRING)
+        .onlyOnQualifiers(Qualifiers.PROJECT)
+        .category(CoreProperties.CATEGORY_SCM)
+        .subCategory(CATEGORY_PERFORCE)
+        .index(4)
+        .build(),
       PropertyDefinition.builder(USESSL_PROP_KEY)
         .name("Use SSL")
         .description("Use SSL protocol (p4javassl://) to connect to server")
@@ -98,24 +108,26 @@ public class PerforceConfiguration implements BatchComponent {
         .onQualifiers(Qualifiers.PROJECT)
         .category(CoreProperties.CATEGORY_SCM)
         .subCategory(CATEGORY_PERFORCE)
-        .index(4)
+        .index(5)
         .build(),
       PropertyDefinition.builder(CHARSET_PROP_KEY)
         .name("Perforce charset")
         .description("Character set used for translation of unicode files (P4CHARSET)")
         .type(PropertyType.STRING)
+        .onQualifiers(Qualifiers.PROJECT)
         .category(CoreProperties.CATEGORY_SCM)
         .subCategory(CATEGORY_PERFORCE)
-        .index(5)
+        .index(6)
         .build(),
       PropertyDefinition.builder(SOCKSOTIMEOUT_PROP_KEY)
         .name("Perforce socket read timeout")
         .description("Sets the socket read timeout for communicating with the Perforce service (milliseconds)")
         .type(PropertyType.INTEGER)
         .defaultValue(String.valueOf(RpcPropertyDefs.RPC_SOCKET_SO_TIMEOUT_DEFAULT))
+        .onQualifiers(Qualifiers.PROJECT)
         .category(CoreProperties.CATEGORY_SCM)
         .subCategory(CATEGORY_PERFORCE)
-        .index(6)
+        .index(7)
         .build());
   }
 
@@ -146,6 +158,11 @@ public class PerforceConfiguration implements BatchComponent {
   @CheckForNull
   public String clientName() {
     return settings.getString(CLIENT_PROP_KEY);
+  }
+
+  @CheckForNull
+  public String clientImpersonatedHostname() {
+    return settings.getString(CLIENT_IMPERSONATED_HOST_PROP_KEY);
   }
 
   public int sockSoTimeout() {

--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforceExecutor.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforceExecutor.java
@@ -29,6 +29,7 @@ import com.perforce.p4java.impl.generic.client.ClientView;
 import com.perforce.p4java.impl.generic.client.ClientView.ClientViewMapping;
 import com.perforce.p4java.impl.mapbased.rpc.RpcPropertyDefs;
 import com.perforce.p4java.impl.mapbased.rpc.sys.helper.RpcSystemFileCommandsHelper;
+import com.perforce.p4java.option.UsageOptions;
 import com.perforce.p4java.option.server.TrustOptions;
 import com.perforce.p4java.server.IOptionsServer;
 import com.perforce.p4java.server.ServerFactory;
@@ -155,13 +156,19 @@ public class PerforceExecutor {
     if (StringUtils.isEmpty(config.port())) {
       throw MessageException.of("Please configure perforce port using " + PerforceConfiguration.PORT_PROP_KEY);
     }
+
     Properties props = new Properties();
     props.put(RpcPropertyDefs.RPC_SOCKET_SO_TIMEOUT_NICK, config.sockSoTimeout());
+
+    UsageOptions usageOptions = new UsageOptions(null);
+    // Param is nullable
+    usageOptions.setHostName(config.clientImpersonatedHostname());
+
     if (config.useSsl()) {
-      server = ServerFactory.getOptionsServer("p4javassl://" + config.port(), props, null);
+      server = ServerFactory.getOptionsServer("p4javassl://" + config.port(), props, usageOptions);
       server.addTrust(new TrustOptions().setAutoAccept(true));
     } else {
-      server = ServerFactory.getOptionsServer("p4java://" + config.port(), props, null);
+      server = ServerFactory.getOptionsServer("p4java://" + config.port(), props, usageOptions);
     }
     // Register server callback.
     server.registerCallback(new CommandLogger());

--- a/src/test/java/org/sonar/plugins/scm/perforce/PerforceConfigurationTest.java
+++ b/src/test/java/org/sonar/plugins/scm/perforce/PerforceConfigurationTest.java
@@ -35,6 +35,7 @@ public class PerforceConfigurationTest {
     PerforceConfiguration config = new PerforceConfiguration(settings);
     assertThat(config.charset()).isNull();
     assertThat(config.clientName()).isNull();
+    assertThat(config.clientImpersonatedHostname()).isNull();
     assertThat(config.port()).isNull();
     assertThat(config.username()).isNull();
     assertThat(config.password()).isNull();

--- a/src/test/java/org/sonar/plugins/scm/perforce/PerforcePluginTest.java
+++ b/src/test/java/org/sonar/plugins/scm/perforce/PerforcePluginTest.java
@@ -27,6 +27,6 @@ public class PerforcePluginTest {
 
   @Test
   public void getExtensions() {
-    assertThat(new PerforcePlugin().getExtensions()).hasSize(10);
+    assertThat(new PerforcePlugin().getExtensions()).hasSize(11);
   }
 }


### PR DESCRIPTION
Provides the equivalent mechanism for setting P4HOST environment
variable or using the -H global option.


... don't ask why I needed it... I'm pretty sure Perforce figured out it hadn't given me a big enough headache recently so it threw me this curveball