### PR TITLE
Multiple improvements

### DIFF
--- a/src/main/java/org/sonar/plugins/scm/perforce/PerforceBlameCommand.java
+++ b/src/main/java/org/sonar/plugins/scm/perforce/PerforceBlameCommand.java
@@ -181,7 +181,7 @@ public class PerforceBlameCommand extends BlameCommand {
   private static GetFileAnnotationsOptions getFileAnnotationOptions() {
     GetFileAnnotationsOptions options = new GetFileAnnotationsOptions();
     options.setUseChangeNumbers(true);
-    options.setFollowBranches(true);
+    options.setFollowAllIntegrations(true);
     options.setIgnoreWhitespaceChanges(true);
     return options;
   }

--- a/src/test/java/org/sonar/plugins/scm/perforce/PerforceBlameCommandTest.java
+++ b/src/test/java/org/sonar/plugins/scm/perforce/PerforceBlameCommandTest.java
@@ -75,27 +75,32 @@ public class PerforceBlameCommandTest {
     IFileAnnotation line1ChangeList3 = mock(IFileAnnotation.class);
     when(line1ChangeList3.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(line1ChangeList3.getLower()).thenReturn(3);
+    when(line1ChangeList3.getLine()).thenReturn("line1");
 
     IFileAnnotation line2ChangeList3 = mock(IFileAnnotation.class);
     when(line2ChangeList3.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(line2ChangeList3.getLower()).thenReturn(3);
+    when(line2ChangeList3.getLine()).thenReturn("line2");
 
     // Changelist 4 is not present in history but can be fetched from server
 
     IFileAnnotation line3ChangeList4 = mock(IFileAnnotation.class);
     when(line3ChangeList4.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(line3ChangeList4.getLower()).thenReturn(4);
+    when(line3ChangeList4.getLine()).thenReturn("line3");
 
     // Changelist 5 is not present in history nor in server
 
     IFileAnnotation line4ChangeList5 = mock(IFileAnnotation.class);
     when(line4ChangeList5.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(line4ChangeList5.getLower()).thenReturn(5);
+    when(line4ChangeList5.getLine()).thenReturn("line4");
 
     // Put Changlist 4 again to verify we fetch only once from server
     IFileAnnotation line5ChangeList4 = mock(IFileAnnotation.class);
     when(line5ChangeList4.getDepotPath()).thenReturn("foo/bar/src/Foo.java");
     when(line5ChangeList4.getLower()).thenReturn(4);
+    when(line5ChangeList4.getLine()).thenReturn("line5");
 
     Map<IFileSpec, List<IFileRevisionData>> result = new HashMap<>();
     IFileSpec fileSpecResult = mock(IFileSpec.class);


### PR DESCRIPTION
I found that "follow all integrations" gives far more accurate results than "follow branches".

There were cases I've run into with CRLF and mixed line endings that do not report blame correctly.  I've added an attempt to account for CRLFs in cases where the P4Java API returns double the annotations than the file has lines.

Added support for multi-threaded blame, which makes things blazingly fast compared to blaming one file at a time.  Code highly resembles the Git blame connector.

I also ran into some cases where connection would fail randomly during blame.  This made it impossible to blame very large projects when running a first-time analysis.  I added a basic retry.

I've been using these changes in production for a month now.  Take it or leave it.